### PR TITLE
Migration du frontend Item vers le mécanisme de déploiement WUD.

### DIFF
--- a/.github/workflows/wud-build-pubtodockerhub.yml
+++ b/.github/workflows/wud-build-pubtodockerhub.yml
@@ -33,6 +33,7 @@ jobs:
           images: ${{ env.DOCKERHUB_IMAGE_PREFIX }}
           flavor: |
             latest=auto
+            suffix=-front
 
       - name: "Login to DockerHub"
         uses: docker/login-action@v3

--- a/.github/workflows/wud-build-pubtodockerhub.yml
+++ b/.github/workflows/wud-build-pubtodockerhub.yml
@@ -1,0 +1,49 @@
+name: wud-build-pubtodockerhub.yml
+
+env:
+  DOCKERHUB_IMAGE_PREFIX: abesesr/item
+
+on:
+  workflow_dispatch:
+
+  repository_dispatch:
+    types:
+      - wud
+
+jobs:
+  build-pubtodockerhub:
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout source code"
+        uses: actions/checkout@v6
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Prepare Docker tags"
+        id: docker_tag_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_IMAGE_PREFIX }}
+          flavor: |
+            latest=auto
+            suffix=-front
+
+      - name: "Login to DockerHub"
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: "Buildx and push"
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          target: front-image
+          tags: ${{ steps.docker_tag_meta.outputs.tags }}

--- a/.github/workflows/wud-build-pubtodockerhub.yml
+++ b/.github/workflows/wud-build-pubtodockerhub.yml
@@ -46,4 +46,4 @@ jobs:
         with:
           push: true
           target: front-image
-          tags: ${{ steps.docker_tag_meta.outputs.tags }}-front
+          tags: ${{ steps.docker_tag_meta.outputs.tags }}

--- a/.github/workflows/wud-build-pubtodockerhub.yml
+++ b/.github/workflows/wud-build-pubtodockerhub.yml
@@ -33,7 +33,6 @@ jobs:
           images: ${{ env.DOCKERHUB_IMAGE_PREFIX }}
           flavor: |
             latest=auto
-            suffix=-front
 
       - name: "Login to DockerHub"
         uses: docker/login-action@v3
@@ -42,8 +41,9 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "Buildx and push"
+        id: push
         uses: docker/build-push-action@v6
         with:
           push: true
           target: front-image
-          tags: ${{ steps.docker_tag_meta.outputs.tags }}
+          tags: ${{ steps.docker_tag_meta.outputs.tags }}-front

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Item",
-  "version": "3.3.10",
+  "version": "3.3.11-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Item",
-      "version": "3.3.10",
+      "version": "3.3.11-SNAPSHOT",
       "dependencies": {
         "@mdi/font": "7.0.96",
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Item",
-  "version": "3.3.10",
+  "version": "3.3.11-SNAPSHOT",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Structure/Maintenance.vue
+++ b/src/components/Structure/Maintenance.vue
@@ -18,7 +18,7 @@ import { computed } from 'vue';
 
 let maintenance = import.meta.env.VITE_MAINTENANCE;
 const warningDialog = computed(() => {
-  return maintenance == true;
+  return maintenance === true;
 });
 
 </script>


### PR DESCRIPTION
## Contexte

Migration du frontend Item vers le mécanisme de déploiement WUD.

## Changements

- Ajout de la GitHub Action `.github/workflows/wud-build-pubtodockerhub.yml`.
- Publication de l'image Docker front vers DockerHub via `docker/build-push-action`.
- Génération des tags Docker avec `docker/metadata-action` et suffixe `-front`, par exemple :
  - `develop-front`
  - `main-front`
  - tags de release suffixés `-front`
- Conservation de `latest=auto`, mais le déploiement WUD repose sur les tags explicites suffixés.
- Passage de la version applicative en `3.3.11-SNAPSHOT`.
- Correction mineure de qualité de code dans `Maintenance.vue` avec l'utilisation de l'égalité stricte.

## Validation attendue

Après merge sur `main`, lancer la GitHub Action `wud-build-pubtodockerhub.yml` pour publier `abesesr/item:main-front`.

WUD pourra ensuite détecter le nouveau digest DockerHub et redéployer `item-front` sur l'environnement de test au prochain passage de son cron.