### PR TITLE
feat(ci): add security scans and update nginx base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ci"
+      - "security"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,42 @@
+name: SonarCloud Analysis
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+  workflow_dispatch:
+
+jobs:
+  sonarcloud:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.SONAR_TOKEN != '' }}
+    steps:
+      - name: "Checkout source code"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Set up Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: "Install dependencies"
+        run: npm ci
+
+      - name: "Build project"
+        run: npm run build
+
+      - name: "SonarCloud scan"
+        uses: SonarSource/sonarqube-scan-action@v4
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.projectKey=abes-esr_item-client
+            -Dsonar.organization=abes-esr
+            -Dsonar.host.url=https://sonarcloud.io
+            -Dsonar.sources=src
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/.github/workflows/wud-build-pubtodockerhub.yml
+++ b/.github/workflows/wud-build-pubtodockerhub.yml
@@ -1,9 +1,20 @@
-name: wud-build-pubtodockerhub.yml
+name: wud-build-pubtodockerhub
 
 env:
   DOCKERHUB_IMAGE_PREFIX: abesesr/item
 
 on:
+  push:
+    branches:
+      - develop
+      - main
+    tags:
+      - "*"
+
+  pull_request:
+    branches:
+      - develop
+
   workflow_dispatch:
 
   repository_dispatch:
@@ -35,7 +46,24 @@ jobs:
             latest=auto
             suffix=-front
 
+      - name: "Build local image for security scan"
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          target: front-image
+          tags: local-front:scan
+
+      - name: "Security: Trivy scan (front-image)"
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          image-ref: 'local-front:scan'
+          format: 'table'
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+
       - name: "Login to DockerHub"
+        if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -45,6 +73,6 @@ jobs:
         id: push
         uses: docker/build-push-action@v6
         with:
-          push: true
+          push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) }}
           target: front-image
           tags: ${{ steps.docker_tag_meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN npm run build
 
 ###
 # Serveur web (nginx) pour exec l'appli vuejs
-FROM nginx:1.20.2 as front-image
+FROM nginx:1.27-alpine as front-image
 COPY --from=build-image /build/dist/ /usr/share/nginx/html.orig/
 COPY ./docker/nginx-default.conf /etc/nginx/conf.d/default.conf
 COPY ./docker/docker-entrypoint.sh /docker-entrypoint.sh


### PR DESCRIPTION
## Summary
- Update nginx base image from 1.20.2 (Nov 2021) to 1.27-alpine (CVE fixes, smaller attack surface)
- Add Trivy container vulnerability scan before DockerHub push (blocks on CRITICAL/HIGH CVEs)
- Add Dependabot config for npm dependencies and GitHub Actions (weekly scans)
- Add SonarCloud SAST analysis workflow (skipped if SONAR_TOKEN not yet configured)

## Test plan
- [ ] Verify Docker image builds correctly with nginx:1.27-alpine
- [ ] Verify nginx config and entrypoint work with Alpine-based image
- [ ] Verify `wud-build-pubtodockerhub` workflow passes with Trivy scan
- [ ] Verify Dependabot creates PRs after merge (check Security tab)
- [ ] Verify SonarCloud workflow is skipped gracefully without SONAR_TOKEN

## Residual risk
- nginx:1.27-alpine uses Alpine Linux instead of Debian — verify custom nginx config compatibility
- Trivy may block the pipeline on first run if CRITICAL CVEs exist — review and fix or add exceptions
- SonarCloud workflow is a no-op until SONAR_TOKEN is added to GitHub secrets